### PR TITLE
Preserve editor content

### DIFF
--- a/js_client/src/interaction/inspectionPoints.ts
+++ b/js_client/src/interaction/inspectionPoints.ts
@@ -87,4 +87,10 @@ document.getElementById("debugEditorButton")?.addEventListener("click", () => {
     const debugEvent = createDebugEvent();
     document.dispatchEvent(debugEvent);
     console.log("Debug event dispatched:", debugEvent);
+
+    localStorage.setItem('urscript', editor.getValue());
+});
+
+editor.addCommand(monaco.KeyMod.CtrlCmd | monaco.KeyCode.KeyS, function() {
+    localStorage.setItem('urscript', editor.getValue());
 });

--- a/js_client/src/interaction/runCode.ts
+++ b/js_client/src/interaction/runCode.ts
@@ -1,5 +1,6 @@
 import {CommandEnteredEvent} from "./EventList";
 import { editor } from "../monacoExperiment";
+import * as monaco from "monaco-editor";
 
 let current_id: number = 0;
 
@@ -17,5 +18,7 @@ document.getElementById('runEditorContentButton')?.addEventListener('click', fun
     console.log(`Command: ${command}`);
     if (command === '') return;
     sendCommand(command);
+
+    localStorage.setItem('urscript', command);
 });
 

--- a/js_client/src/monacoExperiment.ts
+++ b/js_client/src/monacoExperiment.ts
@@ -11,7 +11,9 @@ import {wireTmGrammars} from 'monaco-editor-textmate';
 //as always, shoutout to Ahern guo for the TextMate grammar
 // https://github.com/ahernguo/urscript-extension/blob/master/syntaxes/urscript.tmLanguage.json
 
-const code = `
+
+
+const defaultCode = `
 a = p[-0.421, -0.436, 0.1, 2.61, -1.806, -0.019]
 movej(a, a=0.3, v=0.3)
 
@@ -25,6 +27,8 @@ end
 
 movej(b, a=0.3, v=0.3)
 `;
+
+const code = localStorage.getItem('urscript') || defaultCode;
 
 const editorElement = document.getElementById('editor');
 


### PR DESCRIPTION
with ctrl+s, run code and debug buttons.
Works across reloads of the page, and should persist between browser restarts too.

I can make a save button easily if we want it